### PR TITLE
change generator to use cryptographic RNG instead of Random

### DIFF
--- a/PasswordRulesSharp.Tests/Extensions/RngDotNet4ExtensionsTests.cs
+++ b/PasswordRulesSharp.Tests/Extensions/RngDotNet4ExtensionsTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+using System.Security.Cryptography;
+
+namespace PasswordRulesSharp.Extensions.Tests;
+
+public class RngDotNet4ExtensionsTests
+{
+    public RandomNumberGenerator Rng { get; private set; }
+
+    [SetUp]
+    public void SetUp()
+    {
+        Rng = RandomNumberGenerator.Create();
+    }
+
+    [TestCase(1)]
+    [TestCase(10)]
+    [TestCase(100)]
+    public void GetIndex(int max)
+    {
+        Assert.That(Rng.GetInt32(max), Is.InRange(0, max));
+    }
+}

--- a/PasswordRulesSharp/Extensions/RngDotNet4Extensions.cs
+++ b/PasswordRulesSharp/Extensions/RngDotNet4Extensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Security.Cryptography;
+
+namespace PasswordRulesSharp.Extensions;
+
+public static class RngDotNet4Extensions
+{
+    /// <summary>
+    /// .NET 4-compatible alternative to GetInt32
+    /// </summary>
+    public static int GetInt32(this RandomNumberGenerator rng, int max)
+    {
+        var bytes = new byte[4];
+        rng.GetBytes(bytes);
+
+        uint result;
+
+        result = BitConverter.ToUInt32(bytes, 0);
+
+        return (int)(result % max);
+    }
+}

--- a/PasswordRulesSharp/Generator/Generator.cs
+++ b/PasswordRulesSharp/Generator/Generator.cs
@@ -82,7 +82,9 @@ namespace PasswordRulesSharp.Generator
 
                 foreach (var currentCharset in chars)
                 {
-                    var randomIndex = rng.GetInt32(max: currentCharset.Length);
+                    int randomIndex;
+
+                    randomIndex = rng.GetInt32(max: currentCharset.Length);
 
                     // just pick any char within the selection
                     char randomChar = currentCharset[randomIndex];
@@ -91,6 +93,8 @@ namespace PasswordRulesSharp.Generator
                     {
                         while (HasConsecutiveChar(ref randomChar, ref sb))
                         {
+                            randomIndex = rng.GetInt32(max: currentCharset.Length);
+
                             randomChar = currentCharset[randomIndex];
                         }
                     }

--- a/PasswordRulesSharp/Generator/Generator.cs
+++ b/PasswordRulesSharp/Generator/Generator.cs
@@ -1,8 +1,9 @@
+using PasswordRulesSharp.Extensions;
 using PasswordRulesSharp.Models;
 using PasswordRulesSharp.Rules;
 
-using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 
 using Toore.Shuffling;
@@ -69,8 +70,8 @@ namespace PasswordRulesSharp.Generator
             var chars = ChooseChars();
 
             var sb = new StringBuilder();
-            var random = new Random();
 
+            var rng = RandomNumberGenerator.Create();
             var shuffler = new FisherYatesShuffler(new RandomWrapper());
 
             int i = 0;
@@ -81,14 +82,16 @@ namespace PasswordRulesSharp.Generator
 
                 foreach (var currentCharset in chars)
                 {
+                    var randomIndex = rng.GetInt32(max: currentCharset.Length);
+
                     // just pick any char within the selection
-                    char randomChar = currentCharset[random.Next(currentCharset.Length)];
+                    char randomChar = currentCharset[randomIndex];
 
                     if (Rule.MaxConsecutive.HasValue)
                     {
                         while (HasConsecutiveChar(ref randomChar, ref sb))
                         {
-                            randomChar = currentCharset[random.Next(currentCharset.Length)];
+                            randomChar = currentCharset[randomIndex];
                         }
                     }
 

--- a/PasswordRulesSharp/PasswordRulesSharp.csproj
+++ b/PasswordRulesSharp/PasswordRulesSharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Library</OutputType>


### PR DESCRIPTION
I've been meaning to do this for a while, and https://old.reddit.com/r/dotnet/comments/14euaep/password_generator/jowt6j1/ was another reminder: we shouldn't be using `Random` to help generate passwords.